### PR TITLE
Add periods availability endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -57,6 +57,8 @@ from routes.edit_user import router as edit_user_router
 from routes.delete_rol import router as delete_role_router
 # Geoserver route
 from routes.get_geoserver_point_data import router as get_geoserver_point_data_router
+# Periods route
+from routes.get_available_periods import router as get_available_periods_router
 from fastapi.middleware.cors import CORSMiddleware
 from aclimate_v3_orm.database.base import create_tables
 
@@ -136,6 +138,9 @@ app.include_router(get_climate_historical_daily_by_date_range_and_measures_route
 # Geoserver router
 app.include_router(get_geoserver_point_data_router)
 
+# Periods router
+app.include_router(get_available_periods_router)
+
 
 def startup_event():
     print(" Creando tablas al iniciar...")
@@ -147,4 +152,5 @@ def Apply_migrations():
     print(" Migrations applied.")
     
 #startup_event
+#Apply_migrations()
 #uvicorn main:app --reload

--- a/src/routes/get_available_periods.py
+++ b/src/routes/get_available_periods.py
@@ -1,0 +1,102 @@
+from fastapi import APIRouter
+from typing import List
+from pydantic import BaseModel
+from sqlalchemy import exists
+from sqlalchemy.orm import Session
+from aclimate_v3_orm.database import SessionLocal
+from aclimate_v3_orm.models.climate_historical_indicator import ClimateHistoricalIndicator
+
+class PeriodResponse(BaseModel):
+    value: str
+    label: str
+    has_data: bool
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "value": "annual",
+                "label": "Annual",
+                "has_data": True
+            }
+        }
+
+router = APIRouter(tags=["Periods"], prefix="/periods")
+
+def check_indicator_period_has_data(session: Session, period: str, location_id: int) -> bool:
+    """Check if indicators table has at least one record for a specific period and location"""
+    try:
+        return session.query(
+            exists().where(
+                (ClimateHistoricalIndicator.period == period) & 
+                (ClimateHistoricalIndicator.location_id == location_id)
+            )
+        ).scalar()
+    except:
+        return False
+
+@router.get("/available", response_model=List[PeriodResponse])
+def get_available_periods(location_id: int):
+    """
+    Returns a list of periods (daily, monthly, annual, seasonal, decadal, other) 
+    indicating which ones have data available for a specific location in the climate_historical_indicator table.
+    
+    This endpoint checks the climate_historical_indicator table for different period types
+    filtered by location.
+    
+    Parameters:
+    - **location_id**: ID of the location/station to check for available periods
+    
+    Returns:
+    - **value**: Period identifier (lowercase)
+    - **label**: Human-readable period name
+    - **has_data**: Boolean indicating if there's data for this period
+    """
+    
+    db = SessionLocal()
+    
+    try:
+        # Check for indicator periods for the specific location
+        has_daily = check_indicator_period_has_data(db, "DAILY", location_id)
+        has_monthly = check_indicator_period_has_data(db, "MONTHLY", location_id)
+        has_annual = check_indicator_period_has_data(db, "ANNUAL", location_id)
+        has_seasonal = check_indicator_period_has_data(db, "SEASONAL", location_id)
+        has_decadal = check_indicator_period_has_data(db, "DECADAL", location_id)
+        has_other = check_indicator_period_has_data(db, "OTHER", location_id)
+        
+        # Prepare response
+        periods = [
+            PeriodResponse(
+                value="daily", 
+                label="Daily", 
+                has_data=has_daily
+            ),
+            PeriodResponse(
+                value="monthly", 
+                label="Monthly", 
+                has_data=has_monthly
+            ),
+            PeriodResponse(
+                value="annual", 
+                label="Annual", 
+                has_data=has_annual
+            ),
+            PeriodResponse(
+                value="seasonal", 
+                label="Seasonal", 
+                has_data=has_seasonal
+            ),
+            PeriodResponse(
+                value="decadal", 
+                label="Decadal", 
+                has_data=has_decadal
+            ),
+            PeriodResponse(
+                value="other", 
+                label="Other", 
+                has_data=has_other
+            ),
+        ]
+        
+        return periods
+    finally:
+        db.close()


### PR DESCRIPTION
Introduce a new /periods/available endpoint to report which period types have data for a given location. Adds src/routes/get_available_periods.py with a PeriodResponse model and a helper that queries climate_historical_indicator (via SessionLocal and SQLAlchemy exists) for DAILY, MONTHLY, ANNUAL, SEASONAL, DECADAL and OTHER periods. Registers the new router in src/main.py. The DB session is properly closed in a finally block and the period-check helper returns False on errors.